### PR TITLE
Add home navigation and Taringa styling

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import { searchCharacters } from '../api/axiosConfig'
 
 const Header = () => {
@@ -21,8 +21,16 @@ const Header = () => {
   }
 
   return (
-    <header className="p-4 bg-gray-800 text-white flex items-center">
-      <h1 className="text-xl font-bold mr-4">Rick and Morty</h1>
+    <header className="p-4 bg-gradient-to-r from-blue-600 to-blue-400 text-white flex flex-wrap items-center justify-between">
+      <div className="flex items-center space-x-4 mb-2 sm:mb-0">
+        <h1 className="text-xl font-bold">Rick and Morty</h1>
+        <Link
+          to="/"
+          className="px-3 py-1 bg-blue-800 rounded hover:bg-blue-700"
+        >
+          Home
+        </Link>
+      </div>
       <form onSubmit={handleSearch} className="flex">
         <input
           value={query}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-100 text-gray-900;
+  }
+}

--- a/src/pages/CharacterDetail.tsx
+++ b/src/pages/CharacterDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { Link, useParams } from 'react-router'
 import { fetchCharacter } from '../api/axiosConfig'
 
 const CharacterDetail = () => {
@@ -22,6 +22,12 @@ const CharacterDetail = () => {
 
   return (
     <div className="p-4">
+      <Link
+        to="/"
+        className="inline-block mb-4 px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Home
+      </Link>
       <h2 className="text-xl font-bold">{character.name}</h2>
       <img src={character.image} alt={character.name} className="my-4" />
       <p><strong>Status:</strong> {character.status}</p>

--- a/src/pages/EpisodeDetail.tsx
+++ b/src/pages/EpisodeDetail.tsx
@@ -23,6 +23,12 @@ const EpisodeDetail = () => {
 
   return (
     <div className="p-4">
+      <Link
+        to="/"
+        className="inline-block mb-4 px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Home
+      </Link>
       <EpisodeCard episode={episode} />
       <div className="mt-4">
         <p><strong>Air Date:</strong> {episode.air_date}</p>


### PR DESCRIPTION
## Summary
- update header with Taringa-inspired gradient and home link
- add `Home` buttons to the episode and character detail pages
- apply base body styles for a light grey background

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdd2821a48328b4be42c7f636793a